### PR TITLE
Installing gettext on docker image

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,9 +12,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Installing gettext
-        run: sudo apt-get install gettext
-
       - name: Installing the project
         run: make docker/install
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Installing gettext
+        run: sudo apt-get install gettext
+
       - name: Installing the project
         run: make docker/install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11.0-slim-buster AS base
 
 WORKDIR /src
 
+# Installing gettext
+RUN apt-get update -y && apt-get install gettext -y
+
 COPY pyproject.toml .
 RUN pip install poetry
 
@@ -16,3 +19,7 @@ FROM dependencies AS production
 COPY src src
 COPY settings.conf src
 COPY logging.conf src
+
+# Generating po file with translations
+RUN msgfmt -o src/locales/en/LC_MESSAGES/base.mo src/locales/en/LC_MESSAGES/base.po
+RUN msgfmt -o src/locales/pt_BR/LC_MESSAGES/base.mo src/locales/pt_BR/LC_MESSAGES/base.po

--- a/README.PTBR.md
+++ b/README.PTBR.md
@@ -34,6 +34,7 @@ O SafeChat Slack Bot é um projeto open source desenvolvido para aumentar a segu
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/) - **pré-requisito**
 - [Docker](https://www.docker.com/get-started) - **pré-requisito**
 - [Docker Compose](https://docs.docker.com/compose/) - **pré-requisito**
+- [gettext - Serviço de internacionalização](https://docs.python.org/pt-br/3/library/gettext.html) - **pré-requisito**
 - [Poetry](https://python-poetry.org/) - **pré-requisito**
 - [Ruff](https://github.com/astral-sh/ruff)
 - [Slack Bolt](https://pypi.org/project/slack-bolt/)
@@ -86,7 +87,8 @@ Estrutura de arquivos e pastas:
 1) Crie um novo diretório em `src/locales` com o novo idioma;
 2) Cria um novo arquivo chamado `base.po` nesse novo diretóprio (você pode copiar a estrutura de outro idioma já suportado);
 3) Faça a tradução de todas as mensagens;
-4) Crie os arquivos `mo` usando o comando `make generate-mo-files`.
+4) Crie os arquivos `mo` usando o comando `make generate-mo-files`;
+5) Inclua o comando para gerar o arquivo .po no Dockerfile.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Before you can run the app, you'll need to store some environment variables.
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/) - **pre-requisite**
 - [Docker](https://www.docker.com/get-started) - **pre-requisite**
 - [Docker Compose](https://docs.docker.com/compose/) - **pre-requisite**
+- [gettext - Multilingual internationalization services](https://docs.python.org/pt-br/3/library/gettext.html) - **pre-requisite**
 - [Poetry](https://python-poetry.org/) - **pre-requisite**
 - [Ruff](https://github.com/astral-sh/ruff)
 - [Slack Bolt](https://pypi.org/project/slack-bolt/)
@@ -92,7 +93,8 @@ Locale file structure:
 1) Create a new folder in `src/locales` with the new language;
 2) Create a new `base.po` file inside this folder (you just can copy from another language);
 3) Translate all the messages;
-4) Generate the `mo` files using the command `make generate-mo-files`
+4) Generate the `mo` files using the command `make generate-mo-files`;
+5) Include the command to generate po file on Dockerfile.
 
 ## Logging
 


### PR DESCRIPTION
## What changes do you are proposing? 

The [gettext](https://docs.python.org/pt-br/3/library/gettext.html) is a pre-requisite to use the multilingual internationalization services, so we are installing this lib on the docker image to improve the distribution of this app when we use the `production` target from multi stage docker.

## How did you test these changes? 

- Installing gettext on docker image (using dockerfile);
- Generating `.po` using dockerfile (just on production target);
- Improving the docs about gettext;