### PR TITLE
Fixing poetry and ruff settings about newest versions of them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY pyproject.toml .
 RUN pip install poetry
 
 FROM base AS dependencies
-RUN poetry install --no-dev
+RUN poetry install --without dev
 
 FROM base AS development
 RUN poetry install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   safe-chat-slack-bot:
     tty: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,17 @@ version = "0.1.0"
 description = "SafeChat Slack Bot is an open-source project designed to enhance data security within Slack workspaces"
 authors = ["Marciel Torres <marcielribeirotorres@gmail.com>"]
 license = "MIT"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
 slack-bolt = "1.22.0"
 aiohttp = "3.11.11"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
 pytest-cov = "^6.0.0"
-ruff = "^0.8.1"
+ruff = "^0.9.6"
 
 [tool.pytest.ini_options]
 testpaths = ["tests",]


### PR DESCRIPTION
from https://github.com/marcieltorres/python-boilerplate-project/pull/66

## What changes do you are proposing? 

- Upgrading ruff to 0.9.6 version
- Fixing pyprojetct config adding package mode 
- Using `poetry.group.dev.dependencies` instead of deprecated `poetry.dev-dependencies`
- Removing `version` from docker compose file because is obsolete;