### PR TITLE
Fix Jekyll sitemap XML namespace issues for Google Search Console

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           source: ./
           destination: ./_site
+      - name: Fix sitemap XML namespaces
+        run: |
+          if [ -f ./_site/sitemap.xml ]; then
+            sed -i 's/ xmlns:xsi="[^"]*" xsi:schemaLocation="[^"]*"//g' ./_site/sitemap.xml
+            echo "Sitemap XML namespaces cleaned"
+          else
+            echo "No sitemap.xml found"
+          fi
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
Added post-build step to remove problematic xmlns:xsi and xsi:schemaLocation attributes from sitemap.xml that prevent Google from properly parsing and indexing the sitemap.

ref: https://github.com/jekyll/jekyll-sitemap/issues/320