### PR TITLE
docs: add AGENTS.md for AI coding agent guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,9 @@ poetry.lock
 # Secrets and credentials
 *.pem
 *.credentials
+
+# Claude Code
+.claude/logs/
+.claude/plans/
+.claude/memory/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# AGENTS.md
+
+Guidance for AI coding agents working on this repository. Human contributors should read
+[CONTRIBUTING.md](CONTRIBUTING.md) and [README.md](README.md) first — this file is the condensed,
+machine-facing version.
+
+## Project overview
+
+SafeChat Slack Bot is a Slack bot (Slack Bolt, Socket Mode) that detects PII — Brazilian CPF, email
+addresses and Brazilian phone numbers — in channel messages and replies in-thread asking the author
+not to share sensitive data. Python 3.11, Poetry, Docker-first, i18n via gettext.
+
+## Repo layout
+
+```
+src/bot.py                              entrypoint: builds AsyncApp, starts AsyncSocketModeHandler
+src/listeners/register.py               registers every listener
+src/listeners/messages/regex_message.py new messages matching the compiled pattern
+src/listeners/messages/message_changed.py  edited messages (subtype message_changed)
+src/rules/constants.py                  the regex patterns
+src/rules/pattern.py                    Pattern singleton: compiles the rules, find_all(text) -> int
+src/config/settings.py                  settings.conf + ENV via ConfigParser
+src/config/language.py                  gettext wrapper: language.translate(msgid)
+src/locales/{en,pt_BR}/LC_MESSAGES/base.po  translations
+tests/                                  mirrors src/
+```
+
+## Setup
+
+Prerequisites: Python 3.11, Docker + Docker Compose, `gettext` (provides `msgfmt`), Poetry.
+
+- `make docker/install` — recommended, and what CI runs.
+- `make local/install` — local Poetry install.
+
+Both targets create `.env` from [env.template](env.template) if absent and compile the `.mo` files.
+`.env` and `*.mo` are gitignored and must stay that way — never commit either.
+
+## Commands
+
+| Task | Docker (canonical) | Local |
+| --- | --- | --- |
+| install | `make docker/install` | `make local/install` |
+| tests | `make docker/test` | `make local/tests` |
+| lint | `make docker/lint` | `make local/lint` |
+| lint + autofix | `make docker/lint/fix` | `make local/lint/fix` |
+| run | `make docker/run` | `make local/run` |
+| compile translations | `make generate-mo-files` | `make generate-mo-files` |
+
+CI ([`.github/workflows/pull_request.yml`](.github/workflows/pull_request.yml)) runs
+`make docker/install` → `make docker/lint` → `make docker/test`. See the [Makefile](Makefile) for
+every target.
+
+## Code style
+
+Ruff, configured in [pyproject.toml](pyproject.toml): `line-length = 120`, `target-version = py311`,
+4-space indent, double quotes. Lint rules: `E`, `F`, `W` (pycodestyle/pyflakes), `I` (isort),
+`N` (pep8-naming), `S` (flake8-bandit). Run `make local/lint/fix` before committing.
+
+Project ethos from [CONTRIBUTING.md](CONTRIBUTING.md): be pythonic, DRY, KISS.
+
+## Testing
+
+`pytest` with `testpaths = ["tests"]` and `pythonpath = ["src"]`.
+
+- Tests in this repo are `unittest.TestCase` / `IsolatedAsyncioTestCase` classes with
+  `unittest.mock` (`AsyncMock`, `MagicMock`, `patch`) — **not** bare pytest functions. Follow the
+  existing style.
+- Name tests for the behaviour they assert, e.g. `test_if_text_can_be_a_cpf_with_success`.
+- Coverage runs in branch mode with **`fail_under = 100`** (`src/bot.py` omitted). New code without
+  tests breaks the build.
+- `pytest-asyncio` is installed but no `asyncio_mode` is configured — write async tests with
+  `IsolatedAsyncioTestCase`.
+
+## Adding a detection rule
+
+1. Add the regex to `src/rules/constants.py`.
+2. Append it to `self.rules` in `Pattern.__init__` (`src/rules/pattern.py`).
+3. Add positive **and** negative cases to `tests/rules/test_pattern.py`.
+
+Watch for over-matching: the rules are joined with `|` into one pattern, and the current CPF regex
+matches any run of 11 digits — a phone number counts as a CPF. Assert exact `find_all` counts.
+
+## Internationalization
+
+User-facing strings must go through `language.translate("...")`. Add the msgid to **both**
+`src/locales/en/LC_MESSAGES/base.po` and `src/locales/pt_BR/LC_MESSAGES/base.po`, then run
+`make generate-mo-files`. Adding a new locale also requires a `msgfmt` line in the
+[Dockerfile](Dockerfile).
+
+## Commits and pull requests
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`,
+  `chore:`, `refactor:`, `test:`. (History predates this convention and is inconsistent — follow the
+  convention going forward.)
+- **Never add `Co-Authored-By` lines or any AI / "Generated with" attribution** to commits or PR
+  bodies.
+- Never commit directly to `main` — always work on a branch.
+- An issue must exist before a PR (see the [pull request template](.github/PULL_REQUEST_TEMPLATE)).
+  Reference it with `closes #NN`.
+- Make sure lint and tests pass locally before opening the PR.
+
+## Security
+
+This bot handles credentials and PII by definition. Treat these as hard rules:
+
+- `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` come from environment variables only. Never hardcode a
+  token, never log one, and never paste a real value into docs, tests or fixtures — reference
+  [env.template](env.template) and the variable names instead.
+- **Never log raw message text or matched PII.** Listeners log exceptions only; keep it that way.
+- Do not suppress Ruff `S` (bandit) findings with `# noqa` without a written justification.
+- Changes to scopes in [manifest.json](manifest.json) are security-relevant — call them out
+  explicitly in the pull request.
+- Report vulnerabilities through [SECURITY.md](SECURITY.md), not a public issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See @AGENTS.md for project setup, commands, style, testing and security guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,9 @@ F | [pyflakes](https://pypi.org/project/pyflakes/)
 I | [isort](https://pypi.org/project/isort/)
 N | [pep8-naming](https://pypi.org/project/pep8-naming/)
 S | [flake8-bandit](https://pypi.org/project/flake8-bandit/)
+
+# AI Coding Agents
+
+If you use an AI coding agent (Claude Code, Cursor, Copilot, Codex and friends) to contribute, point it at [AGENTS.md](AGENTS.md). It follows the [agents.md](https://agents.md/) convention and covers setup, commands, code style, testing conventions, commit format and the security rules that apply to this bot — it handles Slack tokens and PII, so those rules are not optional.
+
+You are still responsible for everything you submit: read the diff, run `make local/lint` and `make local/tests`, and make sure the pull request describes the change in your own words.

--- a/README.PTBR.md
+++ b/README.PTBR.md
@@ -72,6 +72,8 @@ run | `make docker/run` | `make local/run` | Para rodar a aplicação
 
 *Confira todos os comandos disponíveis no arquivo [Makefile](Makefile)*.
 
+*Agentes de IA: veja [AGENTS.md](AGENTS.md) para orientações específicas.*
+
 ## Múltiplos Idioma
 
 O Bot consegue interagir com outros idiomas além do Português utilizando o padrão [i18n](https://docs.python.org/3/library/i18n.html).

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ push image | `make docker/image/push` | - | to push the docker image
 
 *Please, check all available commands in the [Makefile](Makefile) for more information*.
 
+*AI coding agents: see [AGENTS.md](AGENTS.md) for agent-specific guidance.*
+
 ## Multi Language
 
 The Bot supports multiple languages using [i18n](https://docs.python.org/3/library/i18n.html) pattern.


### PR DESCRIPTION
## What changes do you are proposing?

Adds a root [`AGENTS.md`](AGENTS.md) following the [agents.md](https://agents.md/) convention — a single plain-Markdown file that gives AI coding agents the context they need to contribute safely to this repository.

Sections: project overview, repo layout, setup, commands (docker + local), code style, testing conventions, how to add a detection rule, i18n, commit/PR format, and security.

Also included:

- **`CLAUDE.md`** — three lines pointing at `AGENTS.md`, so Claude Code picks it up without a second copy of the content. One source of truth.
- **`README.md` / `README.PTBR.md`** — one cross-link line each, under the commands table.
- **`CONTRIBUTING.md`** — a short *AI Coding Agents* section after **Coding Style**.
- **`.gitignore`** — ignore local Claude Code working directories (`.claude/logs/`, `.claude/plans/`, `.claude/memory/`, `.claude/settings.local.json`).

Documentation only — no `src/` or `tests/` file is touched.

### Why the security section matters here

This bot handles Slack tokens and, by definition, PII (CPF, email, phone). `AGENTS.md` states explicitly that tokens come from environment variables only, that raw message text and matched PII must never be logged, that Ruff `S` (bandit) findings are not to be suppressed without justification, and that `manifest.json` scope changes are security-relevant.

## How did you test these changes?

Every command documented in `AGENTS.md` was verified against `Makefile`, `pyproject.toml` and `.github/workflows/pull_request.yml`, and all relative links were checked to resolve.

```
$ make local/lint
All checks passed!

$ make local/tests
26 passed in 0.19s
Required test coverage of 100.0% reached. Total coverage: 100.00%
```

### Noted while writing this, not fixed here

- `README.md` and `README.PTBR.md` document `make docker/tests`, but the actual Makefile target is `docker/test` (`local/tests` is the plural one). `AGENTS.md` documents the correct target. Happy to fix the READMEs in this PR or a follow-up.
- `docker/lint/fix` in the `Makefile` runs `ruff . --fix`, which current Ruff rejects — it needs `ruff check . --fix`, as `local/lint/fix` already does.
- `src/listeners/messages/regex_message.py` has no test file, so it never appears in the coverage report and the 100% gate does not cover it.

**Closing issues**

closes #71