### PR TITLE
feat: automate tag and release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "CHANGELOG.md"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only print the release notes; do not create the tag or the release"
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: "Tag and Publish Release"
+    if: github.repository == 'marcieltorres/safe-chat-slack-bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Read the version from pyproject.toml
+        id: version
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          import tomllib
+
+          with open("pyproject.toml", "rb") as handler:
+              version = tomllib.load(handler)["tool"]["poetry"]["version"]
+
+          if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+              raise SystemExit(f"::error::invalid version in pyproject.toml: {version!r}")
+
+          print(f"version={version}")
+          PY
+
+      - name: Check whether the tag already exists
+        id: tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/${VERSION}" > /dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::tag ${VERSION} already exists, nothing to release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract the release notes from CHANGELOG.md
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          version = os.environ["VERSION"]
+          changelog = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          section = re.search(
+              rf"^## \[{re.escape(version)}\].*?$\n(?P<body>.*?)(?=^## \[|^\[[^\]]+\]:|\Z)",
+              changelog,
+              re.MULTILINE | re.DOTALL,
+          )
+
+          if section is None:
+              raise SystemExit(f"::error::CHANGELOG.md has no '## [{version}]' section")
+
+          body = section.group("body").strip()
+          if not body:
+              raise SystemExit(f"::error::the '## [{version}]' section is empty")
+
+          pathlib.Path("release-notes.md").write_text(f"{body}\n", encoding="utf-8")
+          PY
+          cat release-notes.md
+
+      - name: Create and push the tag
+        if: steps.tag.outputs.exists == 'false' && !inputs.dry_run
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${VERSION}" -m "${VERSION}"
+          git push origin "${VERSION}"
+
+      - name: Publish the GitHub Release
+        if: steps.tag.outputs.exists == 'false' && !inputs.dry_run
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --notes-file release-notes.md \
+            --verify-tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,22 @@ User-facing strings must go through `language.translate("...")`. Add the msgid t
   Reference it with `closes #NN`.
 - Make sure lint and tests pass locally before opening the PR.
 
+## Releases
+
+The tag and the GitHub Release are created automatically by
+[`.github/workflows/release.yml`](.github/workflows/release.yml) when a version without a tag lands
+on `main`. [CONTRIBUTING.md](CONTRIBUTING.md) has the full process.
+
+- **Never create a tag or a GitHub Release by hand** — the workflow owns both.
+- Tags are plain `X.Y.Z`, without a `v` prefix, always derived from `tool.poetry.version` in
+  [pyproject.toml](pyproject.toml).
+- A PR that changes the bot's behaviour must bump `version` in `pyproject.toml` **and** add the
+  matching `## [X.Y.Z] - YYYY-MM-DD` section to [CHANGELOG.md](CHANGELOG.md). Without both, the
+  release never fires.
+- A PR that only touches dependencies, docs or CI does not bump the version.
+- The release notes are the changelog section verbatim, so the section must not be empty — the
+  workflow fails loudly if it is missing or blank.
+
 ## Security
 
 This bot handles credentials and PII by definition. Treat these as hard rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-08
+
+### Added
+
+- Detection of Brazilian CPF, email addresses and Brazilian phone numbers in channel messages.
+- In-thread reply asking the author not to share sensitive data.
+- Support for edited messages (`message_changed` subtype).
+- Internationalization via gettext (`en`, `pt_BR`).
+
+[Unreleased]: https://github.com/marcieltorres/safe-chat-slack-bot/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/marcieltorres/safe-chat-slack-bot/releases/tag/0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,29 @@ I | [isort](https://pypi.org/project/isort/)
 N | [pep8-naming](https://pypi.org/project/pep8-naming/)
 S | [flake8-bandit](https://pypi.org/project/flake8-bandit/)
 
+# Releasing
+
+Releases are cut from `main`. The decision is manual, the mechanics are automated: you bump the version and write the changelog entry inside your pull request, and [`release.yml`](.github/workflows/release.yml) creates the tag and publishes the GitHub Release on merge.
+
+1. In the same pull request as your change, bump `version` in [pyproject.toml](pyproject.toml) following semver.
+2. Move the `## [Unreleased]` content in [CHANGELOG.md](CHANGELOG.md) into a new `## [X.Y.Z] - YYYY-MM-DD` section.
+3. Update the comparison links at the bottom of the changelog.
+4. Merge. The tag and the release show up on their own in about a minute.
+5. If something goes wrong, fix `CHANGELOG.md` and re-run `release` from **Actions → release → Run workflow**. Running it with `dry_run: true` prints the notes without creating anything.
+
+Tags are plain `X.Y.Z`, without a `v` prefix. Never create a tag or a release by hand — the workflow owns both, and it derives the tag from `pyproject.toml` so the two cannot drift apart.
+
+When to bump:
+
+Change | Bump
+--- | ---
+New detection rule, new listener, new locale | minor
+Regex fix, bug fix, translation tweak | patch
+Change to `manifest.json` scopes, breaking configuration change | major
+Dependency bump (Dependabot), docs, CI | none
+
+The release notes are the changelog section verbatim, so write the entry for whoever reads the release page, not for the diff.
+
 # AI Coding Agents
 
 If you use an AI coding agent (Claude Code, Cursor, Copilot, Codex and friends) to contribute, point it at [AGENTS.md](AGENTS.md). It follows the [agents.md](https://agents.md/) convention and covers setup, commands, code style, testing conventions, commit format and the security rules that apply to this bot — it handles Slack tokens and PII, so those rules are not optional.

--- a/README.PTBR.md
+++ b/README.PTBR.md
@@ -1,5 +1,6 @@
 # SafeChat Slack Bot
 
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](CHANGELOG.md)
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SafeChat Slack Bot
 
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](CHANGELOG.md)
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)


### PR DESCRIPTION
## What changes do you are proposing?

The repository had no release process: no tags, no GitHub Releases, no changelog, and
`pyproject.toml` pinned at `0.1.0` since forever. There was no way for someone reporting a bug to
say which version they were running.

This establishes one that is **manual on the decision, automatic on the mechanics**:

- **Human, inside the PR:** bump `version` in `pyproject.toml` and add the matching `CHANGELOG.md`
  entry. Both go through normal review.
- **Workflow, on merge to `main`:** detect a version that has no tag, extract the corresponding
  section from `CHANGELOG.md`, and publish the annotated tag plus the GitHub Release.

The tag is always **derived** from `pyproject.toml`, so the two cannot drift apart. Tags are plain
`X.Y.Z` (no `v` prefix), matching the already published `0.1.0` baseline.

### Files

| File | Change |
| --- | --- |
| `CHANGELOG.md` | New. Keep a Changelog 1.1.0, seeded with `[Unreleased]` and `[0.1.0]` |
| `.github/workflows/release.yml` | New. Creates the tag and publishes the Release |
| `CONTRIBUTING.md` | New `Releasing` section with the bump-criteria table |
| `AGENTS.md` | New `Releases` section so agents know the bump belongs in the PR |
| `README.md` / `README.PTBR.md` | Release badge linking to the changelog |

The badge is sourced from the latest GitHub Release (`img.shields.io/github/v/release/…`) rather
than hardcoded, so it follows the releases this workflow publishes with no manual step. Hardcoding
the number would have put the version in two more places — both READMEs — with nothing to stop it
drifting from the tag. It also closes the issue's "a reporter can tell which release they are on"
criterion at a glance instead of via the Releases tab.

### Why not semantic-release / release-please

Both need to commit the bump and changelog back to `main`. `main` is protected
(`required_approving_review_count: 1`, `require_code_owner_reviews: true`) and this is a user-owned
repo, so `bypass_pull_request_allowances` is not available — it would take a GitHub App with a
private key stored as a secret plus migrating to rulesets. For a repo whose product is a security
bot handling PII, a job with `contents: write` pushing straight to `main` from a long-lived
credential is a poor risk trade.

Creating a **tag and a Release** is not covered by branch protection, and
`gh api repos/marcieltorres/safe-chat-slack-bot/rulesets` returns `[]`, so there is no tag ruleset
either. The default `GITHUB_TOKEN` is sufficient — **no new secrets**.

### Idempotency

The workflow checks whether the tag already exists rather than diffing `pyproject.toml` against
`HEAD^`. Re-runs, `workflow_dispatch`, and bumps that arrive alongside other changes in the same
squash commit all behave identically. If the tag exists, the job exits successfully with a
`::notice::`.

### Security notes

- `permissions: {}` at workflow level; `contents: write` only on the job.
- **No `${{ }}` interpolated inside any `run:` block** — everything passes through `env:`. This is
  the standard script-injection mitigation and non-negotiable in this repo.
- The version is validated against `^\d+\.\d+\.\d+$` before it becomes a tag name or a shell
  argument.
- `actions/checkout` pinned to `@v7`, matching how every other workflow in this repo references
  actions. A commit-SHA pin was considered and dropped: it would be the only action in the repo
  pinned that way, `actions/checkout` is first-party (`actions/*`) rather than a third-party action,
  and with no `github-actions` entry in `dependabot.yml` a SHA pin would freeze past upstream
  security patches with nothing to bump it.
- `if: github.repository == '…'` prevents forks from firing the workflow.
- Nothing is ever pushed to `main`; branch protection stays intact with no bypass actor.
- **`manifest.json` is not touched — no Slack scopes change in this PR.**
- No `# noqa` for any Ruff `S` rule is introduced.

## How did you test these changes?

No production Python is added — the parsing logic lives inline in the workflow YAML, outside the
reach of `--cov .`, so the `fail_under = 100` gate is unaffected.

**1. Lint and tests**

```
$ make docker/lint
All checks passed!

$ make docker/test
26 passed in 0.24s
Required test coverage of 100.0% reached. Total coverage: 100.00%
```

**2. Changelog extraction, exercised locally against the real file and the failure paths**

| Case | Result |
| --- | --- |
| `0.1.0` against the real `CHANGELOG.md` | notes extracted, link footer correctly excluded |
| version with no section (`9.9.9`) | `::error::CHANGELOG.md has no '## [9.9.9]' section` |
| section present but empty (`Unreleased`) | `::error::the '## [Unreleased]' section is empty` |
| newest version in a multi-version file | stops at the next `## [`, does not bleed |
| oldest version in a multi-version file | stops before the link footer |

Note: the terminator is `(?=^## \[|^\[[^\]]+\]:|\Z)`. The `^\[[^\]]+\]:` alternative matters —
without it the **oldest** section runs to end-of-file and swallows the `[Unreleased]: …` link
definitions into the release notes, which is exactly the case that applies to `0.1.0` today.

**3. Version validation**

`0.1.0` and `1.20.3` accepted; `0.1`, `0.1.0-rc1`, `v0.1.0`, `0.1.0 && rm -rf /` and `""` all
rejected.

**4. Workflow structure**

`release.yml` parsed with PyYAML: `permissions: {}` at top level, `contents: write` scoped to the
job, six steps, `fetch-depth: 0` on checkout. A line-by-line scan of every `run:` literal block
confirms zero `${{ }}` occurrences inside them.

`fetch-depth: 0` is load-bearing, not decorative: it is what makes `actions/checkout` fetch
`+refs/tags/*:refs/tags/*`, which is what lets the tag-existence check see existing tags. Dropping
it to `1` would make the check always report "not found" and the job would then fail on
`git push` of an already-published tag.

### Follow-up after merge

- Fill the empty body of the existing `0.1.0` Release from the new changelog section.
- Run `release` via `workflow_dispatch` with `dry_run: true` to validate end to end.

### Deliberately out of scope

Filed separately rather than bundled here: a `pull_request.yml` guard failing the PR when the
version changes without a changelog section; making the PR checks required
(`required_status_checks.contexts` is `[]` today); upgrading `actions/checkout@v2` (Node 16,
deprecated) and `codecov/codecov-action@v4.0.1` in `pull_request.yml`.

closes #104
