### PR TITLE
fix: point the release badge at an absolute changelog URL

### DIFF
--- a/README.PTBR.md
+++ b/README.PTBR.md
@@ -1,6 +1,6 @@
 # SafeChat Slack Bot
 
-[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](CHANGELOG.md)
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SafeChat Slack Bot
 
-[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](CHANGELOG.md)
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)


### PR DESCRIPTION
## What changes do you are proposing?

The release badge added in #105 linked to `CHANGELOG.md` relatively. That resolves on github.com but
not on the Pages site, where clicking it serves the raw file as `text/markdown`.

This switches the badge target to an absolute URL in `README.md` and `README.PTBR.md`:

```diff
-[![release](…/github/v/release/…)](CHANGELOG.md)
+[![release](…/github/v/release/…)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
```

No version bump and no changelog entry: per the bump table in `CONTRIBUTING.md`, a docs change does
not bump. The `release` workflow will therefore not fire for this merge, which is the intended
behaviour.

### Root cause

The page was never the problem — `/CHANGELOG.html` builds and returns `200 text/html`. What fails is
**link rewriting**.

GitHub Pages (gem `github-pages` 232) pins `jekyll-relative-links` at **v0.6.1**:

```ruby
LINK_TEXT_REGEX   = %r!(.*?)!
INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!
```

A badge is a link whose text is itself an image link. The lazy `(.*?)` therefore matches the *inner*
image first — link text `![release`, target `https://img.shields.io/…`. That target is absolute, so
`replaceable_link?` returns false and the plugin skips it. Scanning resumes *after* the match,
leaving `](CHANGELOG.md)` with no opening bracket, so the real target is never evaluated.

Upstream `master` fixed this by adding an image-link alternative to `LINK_TEXT_REGEX`, but the
version is pinned by `actions/jekyll-build-pages@v1` and cannot be changed from this repo. So **any**
relative markdown target inside a badge has the same fate — this is not specific to the changelog.

An absolute URL sidesteps rewriting entirely, and matches what the license badge in the same block
already does.

## How did you test these changes?

**Evidence for the diagnosis**, from the currently published site:

```
/CHANGELOG.html    200  text/html          ← the page renders fine
/CHANGELOG.md      200  text/markdown      ← what the badge was hitting
```

And in the published `index.html`, from the same README:

```
href="/safe-chat-slack-bot/AGENTS.html"    ← plain link, rewritten
href="CHANGELOG.md"                        ← badge link, not rewritten
```

That contrast is the fix's whole justification: same file, same build, only the badge fails.

**Plugin versions** confirmed against `https://pages.github.com/versions.json`
(`jekyll-relative-links` 0.6.1), and the regex read from the v0.6.1 tag rather than `master`, since
`master` contains the fix that is not shipped here.

**New target** `https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md` returns
`200 text/html`.

Lint and tests were not re-run locally — the change is two markdown lines, outside the reach of both
`ruff` and `pytest`. CI covers it.

## Separate issue found while investigating

`/CONTRIBUTING.html` and `/CODE_OF_CONDUCT.html` return **404** on the Pages site. Unrelated cause:
`jekyll-optional-front-matter` v0.3.2 carries a `FILENAME_BLACKLIST` of `README`, `LICENSE`,
`LICENCE`, `COPYING`, `CODE_OF_CONDUCT` and `CONTRIBUTING`, so those files are never converted to
pages. `CHANGELOG` is not on that list, which is why it converts. Adding YAML front matter to the two
files opts them back in. Deliberately left out of this PR.

closes #106
