### PR TITLE
fix: use a reference link so the badge resolves on GitHub Pages

### DIFF
--- a/README.PTBR.md
+++ b/README.PTBR.md
@@ -1,6 +1,6 @@
 # SafeChat Slack Bot
 
-[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)][changelog]
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)
@@ -110,3 +110,5 @@ Esse projeto usa uma maneira muito simples para configurar os logs com o arquivo
 ---
 
 [![Fork me on GitHub](https://img.shields.io/badge/Fork%20me%20on-GitHub-brightgreen?style=for-the-badge&logo=github)](https://github.com/marcieltorres/safe-chat-slack-bot/fork)
+
+[changelog]: CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SafeChat Slack Bot
 
-[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
+[![release](https://img.shields.io/github/v/release/marcieltorres/safe-chat-slack-bot)][changelog]
 [![GitHub stars](https://img.shields.io/github/stars/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/marcieltorres/safe-chat-slack-bot?style=social)](https://github.com/marcieltorres/safe-chat-slack-bot/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/marcieltorres/safe-chat-slack-bot)](https://github.com/marcieltorres/safe-chat-slack-bot/issues)
@@ -116,3 +116,5 @@ This project uses a simple way to manage the settings with [settings.conf](setti
 ---
 
 [![Fork me on GitHub](https://img.shields.io/badge/Fork%20me%20on-GitHub-brightgreen?style=for-the-badge&logo=github)](https://github.com/marcieltorres/safe-chat-slack-bot/fork)
+
+[changelog]: CHANGELOG.md


### PR DESCRIPTION
## What changes do you are proposing?

#107 fixed the raw-markdown response by making the badge point at an absolute `github.com` URL, but
that sends readers off the Pages site — unlike every other markdown link there, which stays on it.

This uses a **reference-style link** instead, so the target goes back to being relative:

```diff
-[![release](…)](https://github.com/marcieltorres/safe-chat-slack-bot/blob/main/CHANGELOG.md)
+[![release](…)][changelog]

+[changelog]: CHANGELOG.md
```

### Why this works where the inline form did not

`jekyll-relative-links` v0.6.1 (pinned by GitHub Pages) fails on badges because its
`INLINE_LINK_REGEX` matches the *inner* image — it sees the absolute shields.io URL as the target
and skips the construct, leaving the real target unread.

`REFERENCE_LINK_REGEX` has no such problem. It matches a definition on its own line:

```ruby
REFERENCE_LINK_REGEX = %r!^\s*?\[(.*?)\]: (.+?)#{FRAGMENT_REGEX}\s*?$!
```

So `[changelog]: CHANGELOG.md` is matched, found relative and markdown, and rewritten to
`CHANGELOG.html` — the same path `[AGENTS.md](AGENTS.md)` already takes.

Applies to `README.md` and `README.PTBR.md`. Docs only, so no version bump per the `CONTRIBUTING.md`
bump table.

## How did you test these changes?

Both v0.6.1 regexes were reimplemented and run against the new `README.md`:

```
=== INLINE matches ===
  target='AGENTS.md'                          replaceable=True
  target='https://img.shields.io/...'         replaceable=False   (every badge image)

=== REFERENCE matches ===
  [changelog]: 'CHANGELOG.md'  ->  replaceable=True  ->  CHANGELOG.html
```

The badge images stay untouched (correct — they are absolute), and the changelog target is now
picked up and rewritten.

It also still resolves on github.com, where reference links are plain markdown.

Final confirmation is the Pages deploy on merge: the published `index.html` should carry
`href="CHANGELOG.html"` where it currently carries the absolute blob URL.